### PR TITLE
Add Spring Boot account service skeleton

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+/gradlew text eol=lf
+*.bat text eol=crlf
+*.jar binary

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,29 @@
+HELP.md
+target/
+!.mvn/wrapper/maven-wrapper.jar
+
+### STS ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+bin/
+
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr
+out/
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+
+### VS Code ###
+.vscode/

--- a/README.md
+++ b/README.md
@@ -1,95 +1,44 @@
 # Accounts Service
 
-Service for managing providers and customers in the Car Services Marketplace.
+Spring Boot microservice that manages providers for the Car Services Marketplace.
 
 ## Features
 
-- Provider registration and updates
-- Geo-based nearby provider search
-- Provider event publishing (Kafka)
-- OpenAPI 3.1 documentation
-- Role-based access control
-- Observability with OpenTelemetry
+- Register and update providers
+- Fetch provider by id
+- Nearby provider search using PostGIS
+- OpenAPI 3.1 contract (`src/main/resources/openapi.yaml`)
 
 ## Tech Stack
 
-- Java 21 + Spring Boot 3
-- PostgreSQL + PostGIS (geo queries)
-- Kafka (event publishing)
-- OpenAPI 3.1
-- Keycloak (auth)
-- OpenTelemetry
+- Java 17
+- Spring Boot 3
+- Maven build
+- PostgreSQL + PostGIS
+- Kafka (events, not fully implemented)
 
-## Dependencies
+## Building & Testing
 
-- `common-domain`: Core domain primitives
-- `common-messaging`: Event schemas and serialization
-
-## Build & Run
-
-### Prerequisites
-
-- Java 21
-- Docker & Docker Compose
-- PostgreSQL with PostGIS
-- Kafka (or Redpanda)
-- Keycloak
-
-### Local Development
-
-1. Start dependencies:
-   ```bash
-   docker-compose up -d
-   ```
-
-2. Build:
-   ```bash
-   ./mvnw clean install
-   ```
-
-3. Run:
-   ```bash
-   ./mvnw spring-boot:run
-   ```
-
-### API Documentation
-
-OpenAPI UI available at: http://localhost:8081/api/accounts/swagger-ui.html
-
-### Main Endpoints
-
-- `POST /api/accounts/providers` - Register/update provider
-- `GET /api/accounts/providers/{id}` - Get provider by ID
-- `GET /api/accounts/providers/nearby` - Find nearby providers
-
-### Configuration
-
-Key properties in `application.yml`:
-- Database connection
-- Kafka settings
-- Security (JWT)
-- Observability
-
-## Testing
-
-Run tests:
 ```bash
-./mvnw test
+mvn test
 ```
 
-Integration tests use Testcontainers for PostgreSQL and Kafka.
+## Running Locally
 
-## Design
+The application expects a PostgreSQL database. Configure credentials in
+`src/main/resources/application.properties` or via environment variables.
 
-- Hexagonal Architecture
-- Domain-Driven Design
-- Event-Driven (outbox pattern)
-- CQRS (separate read/write models)
+Start the app:
 
-## Event Publishing
+```bash
+mvn spring-boot:run
+```
 
-Events published to Kafka:
-- `ProviderRegistered`
-- `ProviderUpdated`
+## API Endpoints
 
-Uses outbox pattern for reliability.
+- `POST /api/accounts/providers` – register a provider
+- `PUT /api/accounts/providers/{id}` – update a provider
+- `GET /api/accounts/providers/{id}` – fetch provider by id
+- `GET /api/accounts/providers/nearby` – search providers near a location
+
+See `openapi.yaml` for full request/response models.

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,110 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.5.5</version>
+        <relativePath/>
+    </parent>
+
+    <groupId>com.marketplace</groupId>
+    <artifactId>account-service</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>Account Service</name>
+    <description>Account Service</description>
+
+    <properties>
+        <java.version>17</java.version>
+        <lombok.version>1.18.32</lombok.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.kafka</groupId>
+            <artifactId>spring-kafka</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate.orm</groupId>
+            <artifactId>hibernate-spatial</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.locationtech.jts</groupId>
+            <artifactId>jts-core</artifactId>
+            <version>1.19.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>${lombok.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.kafka</groupId>
+            <artifactId>spring-kafka-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <version>${lombok.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/src/main/java/com/marketplace/accounts/AccountServiceApplication.java
+++ b/src/main/java/com/marketplace/accounts/AccountServiceApplication.java
@@ -1,0 +1,13 @@
+package com.marketplace.accounts;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class AccountServiceApplication {
+
+	public static void main(String[] args) {
+		SpringApplication.run(AccountServiceApplication.class, args);
+	}
+
+}

--- a/src/main/java/com/marketplace/accounts/controller/ProviderController.java
+++ b/src/main/java/com/marketplace/accounts/controller/ProviderController.java
@@ -1,0 +1,82 @@
+package com.marketplace.accounts.controller;
+
+import com.marketplace.accounts.domain.Provider;
+import com.marketplace.accounts.dto.ProviderRequest;
+import com.marketplace.accounts.dto.ProviderResponse;
+import com.marketplace.accounts.service.ProviderService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@RestController
+@RequestMapping("/api/accounts/providers")
+@RequiredArgsConstructor
+public class ProviderController {
+
+    private final ProviderService service;
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public ProviderResponse register(@Validated @RequestBody ProviderRequest request) {
+        Provider provider = service.register(
+                request.getName(),
+                request.getServices(),
+                request.getLat(),
+                request.getLon());
+        return toResponse(provider, null);
+    }
+
+    @PutMapping("/{id}")
+    public ProviderResponse update(@PathVariable UUID id, @Validated @RequestBody ProviderRequest request) {
+        Provider provider = service.update(id, request.getName(), request.getServices(), request.getLat(), request.getLon());
+        return toResponse(provider, null);
+    }
+
+    @GetMapping("/{id}")
+    public ProviderResponse byId(@PathVariable UUID id) {
+        Provider provider = service.get(id);
+        if (provider == null) {
+            throw new ProviderNotFoundException(id);
+        }
+        return toResponse(provider, null);
+    }
+
+    @GetMapping("/nearby")
+    public List<ProviderResponse> nearby(@RequestParam double lat,
+                                         @RequestParam double lon,
+                                         @RequestParam(defaultValue = "10") double radiusMi,
+                                         @RequestParam(defaultValue = "50") int limit) {
+        List<Provider> providers = service.nearby(lat, lon, radiusMi, limit);
+        return providers.stream()
+                .map(p -> toResponse(p, null))
+                .collect(Collectors.toList());
+    }
+
+    private ProviderResponse toResponse(Provider p, Double distanceMi) {
+        double lat = p.getLocation() != null ? p.getLocation().getY() : 0;
+        double lon = p.getLocation() != null ? p.getLocation().getX() : 0;
+        List<String> services = p.getServices() != null ? Arrays.asList(p.getServices().split(",")) : List.of();
+        return ProviderResponse.builder()
+                .id(p.getId())
+                .name(p.getName())
+                .services(services)
+                .rating(p.getRating())
+                .lat(lat)
+                .lon(lon)
+                .distance(distanceMi)
+                .build();
+    }
+
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    private static class ProviderNotFoundException extends RuntimeException {
+        ProviderNotFoundException(UUID id) {
+            super("Provider not found: " + id);
+        }
+    }
+}

--- a/src/main/java/com/marketplace/accounts/domain/Provider.java
+++ b/src/main/java/com/marketplace/accounts/domain/Provider.java
@@ -1,0 +1,37 @@
+package com.marketplace.accounts.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.locationtech.jts.geom.Point;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+@Entity
+@Table(name = "providers")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Provider {
+    @Id
+    @GeneratedValue
+    private UUID id;
+
+    @Column(nullable = false)
+    private String name;
+
+    /**
+     * Comma separated list of service tags offered by the provider.
+     */
+    @Column(nullable = false)
+    private String services;
+
+    private BigDecimal rating;
+
+    /**
+     * Location stored as PostGIS geometry point in WGS84 (lat/lon).
+     */
+    @Column(columnDefinition = "geometry(Point,4326)")
+    private Point location;
+}

--- a/src/main/java/com/marketplace/accounts/dto/ProviderRequest.java
+++ b/src/main/java/com/marketplace/accounts/dto/ProviderRequest.java
@@ -1,0 +1,23 @@
+package com.marketplace.accounts.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class ProviderRequest {
+    @NotBlank
+    private String name;
+
+    @NotEmpty
+    private List<String> services;
+
+    @NotNull
+    private Double lat;
+
+    @NotNull
+    private Double lon;
+}

--- a/src/main/java/com/marketplace/accounts/dto/ProviderResponse.java
+++ b/src/main/java/com/marketplace/accounts/dto/ProviderResponse.java
@@ -1,0 +1,22 @@
+package com.marketplace.accounts.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.UUID;
+
+@Data
+@AllArgsConstructor
+@Builder
+public class ProviderResponse {
+    private UUID id;
+    private String name;
+    private List<String> services;
+    private BigDecimal rating;
+    private Double lat;
+    private Double lon;
+    private Double distance; // miles
+}

--- a/src/main/java/com/marketplace/accounts/repository/ProviderRepository.java
+++ b/src/main/java/com/marketplace/accounts/repository/ProviderRepository.java
@@ -1,0 +1,19 @@
+package com.marketplace.accounts.repository;
+
+import com.marketplace.accounts.domain.Provider;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface ProviderRepository extends JpaRepository<Provider, UUID> {
+
+    @Query(value = "SELECT * FROM providers p WHERE ST_DWithin(p.location, ST_SetSRID(ST_MakePoint(:lon,:lat),4326), :radius) " +
+            "ORDER BY ST_DistanceSphere(p.location, ST_SetSRID(ST_MakePoint(:lon,:lat),4326)) LIMIT :limit", nativeQuery = true)
+    List<Provider> searchNearby(@Param("lat") double lat,
+                                @Param("lon") double lon,
+                                @Param("radius") double radius,
+                                @Param("limit") int limit);
+}

--- a/src/main/java/com/marketplace/accounts/service/ProviderService.java
+++ b/src/main/java/com/marketplace/accounts/service/ProviderService.java
@@ -1,0 +1,48 @@
+package com.marketplace.accounts.service;
+
+import com.marketplace.accounts.domain.Provider;
+import com.marketplace.accounts.repository.ProviderRepository;
+import lombok.RequiredArgsConstructor;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.geom.PrecisionModel;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class ProviderService {
+
+    private final ProviderRepository repository;
+    private final GeometryFactory geometryFactory = new GeometryFactory(new PrecisionModel(), 4326);
+
+    public Provider register(String name, List<String> services, double lat, double lon) {
+        Point location = geometryFactory.createPoint(new Coordinate(lon, lat));
+        Provider provider = Provider.builder()
+                .name(name)
+                .services(String.join(",", services))
+                .location(location)
+                .build();
+        return repository.save(provider);
+    }
+
+    public Provider update(UUID id, String name, List<String> services, double lat, double lon) {
+        Provider provider = repository.findById(id).orElseThrow();
+        provider.setName(name);
+        provider.setServices(String.join(",", services));
+        provider.setLocation(geometryFactory.createPoint(new Coordinate(lon, lat)));
+        return repository.save(provider);
+    }
+
+    public Provider get(UUID id) {
+        return repository.findById(id).orElse(null);
+    }
+
+    public List<Provider> nearby(double lat, double lon, double radiusMi, int limit) {
+        double radiusMeters = radiusMi * 1609.34;
+        return repository.searchNearby(lat, lon, radiusMeters, limit);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,4 @@
+spring.application.name=account-service
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
+spring.jpa.database-platform=org.hibernate.spatial.dialect.postgis.PostgisPG95Dialect

--- a/src/main/resources/openapi.yaml
+++ b/src/main/resources/openapi.yaml
@@ -1,0 +1,112 @@
+openapi: 3.1.0
+info:
+  title: Account Service API
+  version: 0.1.0
+paths:
+  /api/accounts/providers:
+    post:
+      summary: Register provider
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ProviderRequest'
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProviderResponse'
+    get:
+      summary: List nearby providers
+      parameters:
+        - name: lat
+          in: query
+          required: true
+          schema:
+            type: number
+        - name: lon
+          in: query
+          required: true
+          schema:
+            type: number
+        - name: radiusMi
+          in: query
+          schema:
+            type: number
+            default: 10
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            default: 50
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ProviderResponse'
+  /api/accounts/providers/{id}:
+    get:
+      summary: Get provider by id
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProviderResponse'
+components:
+  schemas:
+    ProviderRequest:
+      type: object
+      properties:
+        name:
+          type: string
+        services:
+          type: array
+          items:
+            type: string
+        lat:
+          type: number
+        lon:
+          type: number
+      required:
+        - name
+        - services
+        - lat
+        - lon
+    ProviderResponse:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+        services:
+          type: array
+          items:
+            type: string
+        rating:
+          type: number
+          format: double
+        lat:
+          type: number
+        lon:
+          type: number
+        distance:
+          type: number
+          description: Distance in miles from search origin

--- a/src/test/java/com/marketplace/accounts/ProviderServiceTest.java
+++ b/src/test/java/com/marketplace/accounts/ProviderServiceTest.java
@@ -1,0 +1,35 @@
+package com.marketplace.accounts;
+
+import com.marketplace.accounts.domain.Provider;
+import com.marketplace.accounts.repository.ProviderRepository;
+import com.marketplace.accounts.service.ProviderService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ProviderServiceTest {
+
+    @Mock
+    ProviderRepository repository;
+
+    @InjectMocks
+    ProviderService service;
+
+    @Test
+    void registerSavesProvider() {
+        when(repository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+        Provider provider = service.register("Joe's Garage", List.of("oil-change"), 40.0, -70.0);
+        assertThat(provider.getName()).isEqualTo("Joe's Garage");
+        verify(repository).save(any());
+    }
+}


### PR DESCRIPTION
## Summary
- scaffold Spring Boot account service
- implement provider register, update, fetch and nearby APIs
- include OpenAPI contract and unit test
- switch build system from Gradle to Maven

## Testing
- `mvn test` *(fails: Non-resolvable parent POM - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68afcaa727f8832c9b86387824c1016d