### PR TITLE
Configure PostgreSQL via AWS Secrets Manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ mvn test
 
 The application expects a PostgreSQL database. Configure credentials in
 `src/main/resources/application.properties` or via environment variables.
+When running on AWS EC2, the service fetches connection details from AWS
+Secrets Manager. The secret name defaults to `db_connect` and should contain a
+JSON object with the fields `username`, `password`, `host`, `port` and
+`dbname`.
 
 Start the app:
 

--- a/src/main/java/com/marketplace/accounts/config/DataSourceConfig.java
+++ b/src/main/java/com/marketplace/accounts/config/DataSourceConfig.java
@@ -1,0 +1,49 @@
+package com.marketplace.accounts.config;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marketplace.accounts.utils.CommonUtils;
+import com.zaxxer.hikari.HikariDataSource;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import javax.sql.DataSource;
+
+/**
+ * Configures the application's {@link DataSource} by retrieving database
+ * credentials from AWS Secrets Manager. The secret is expected to contain a
+ * JSON document with keys: username, password, host, port and dbname.
+ */
+@Configuration
+public class DataSourceConfig {
+
+    @Value("${aws.secret.name:db_connect}")
+    private String secretName;
+
+    @Value("${aws.region:us-east-1}")
+    private String region;
+
+    @Bean
+    public DataSource dataSource() throws Exception {
+        String secret = CommonUtils.getSecret(secretName, region);
+
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode root = mapper.readTree(secret);
+
+        String username = root.get("username").asText();
+        String password = root.get("password").asText();
+        String host = root.get("host").asText();
+        String dbname = root.get("dbname").asText();
+        int port = root.get("port").asInt();
+
+        String jdbcUrl = String.format("jdbc:postgresql://%s:%d/%s", host, port, dbname);
+
+        HikariDataSource dataSource = new HikariDataSource();
+        dataSource.setJdbcUrl(jdbcUrl);
+        dataSource.setUsername(username);
+        dataSource.setPassword(password);
+        dataSource.setDriverClassName("org.postgresql.Driver");
+        return dataSource;
+    }
+}

--- a/src/main/java/com/marketplace/accounts/utils/CommonUtils.java
+++ b/src/main/java/com/marketplace/accounts/utils/CommonUtils.java
@@ -9,33 +9,31 @@ import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueRespon
 @Component
 public class CommonUtils {
 
-
-    public static void getSecret() {
-
-        String secretName = "db_connect";
-        Region region = Region.of("us-east-1");
+    /**
+     * Fetches a secret value from AWS Secrets Manager.
+     *
+     * @param secretName the name of the secret to retrieve
+     * @param region     AWS region where the secret is stored
+     * @return the secret string retrieved from Secrets Manager
+     */
+    public static String getSecret(String secretName, String region) {
 
         // Create a Secrets Manager client
         SecretsManagerClient client = SecretsManagerClient.builder()
-                .region(region)
+                .region(Region.of(region))
                 .build();
 
         GetSecretValueRequest getSecretValueRequest = GetSecretValueRequest.builder()
                 .secretId(secretName)
                 .build();
 
-        GetSecretValueResponse getSecretValueResponse;
-
         try {
-            getSecretValueResponse = client.getSecretValue(getSecretValueRequest);
+            GetSecretValueResponse getSecretValueResponse = client.getSecretValue(getSecretValueRequest);
+            return getSecretValueResponse.secretString();
         } catch (Exception e) {
             // For a list of exceptions thrown, see
             // https://docs.aws.amazon.com/secretsmanager/latest/apireference/API_GetSecretValue.html
-            throw e;
+            throw new RuntimeException("Unable to retrieve secret from AWS Secrets Manager", e);
         }
-
-        String secret = getSecretValueResponse.secretString();
-
-        // Your code goes here.
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -12,6 +12,12 @@ spring.datasource.password=
 spring.datasource.driver-class-name=org.postgresql.Driver
 
 # ===============================
+# AWS Secrets Manager
+# ===============================
+aws.secret.name=db_connect
+aws.region=us-east-1
+
+# ===============================
 # Connection Pool (HikariCP)
 # ===============================
 spring.datasource.hikari.maximum-pool-size=10


### PR DESCRIPTION
## Summary
- Add `DataSourceConfig` to build a JDBC `DataSource` using credentials fetched from AWS Secrets Manager
- Expand `CommonUtils` with parameterized `getSecret` helper for retrieving secrets
- Document AWS Secrets Manager usage and expose `aws.secret.name`/`aws.region` properties

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b108d5f150832c956020e7c7e63c0f