### PR TITLE
Add Flyway migration support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,6 +101,15 @@
             <artifactId>secretsmanager</artifactId>
             <version>2.32.23</version>
         </dependency>
+        <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-database-postgresql</artifactId>
+            <scope>runtime</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/resources/application-loc.properties
+++ b/src/main/resources/application-loc.properties
@@ -14,6 +14,11 @@ spring.datasource.password=
 spring.datasource.driver-class-name=org.h2.Driver
 
 # ===============================
+# Flyway
+# ===============================
+spring.flyway.enabled=false
+
+# ===============================
 # JPA / Hibernate
 # ===============================
 spring.jpa.hibernate.ddl-auto=update

--- a/src/main/resources/application-uat.properties
+++ b/src/main/resources/application-uat.properties
@@ -27,6 +27,12 @@ spring.datasource.hikari.connection-timeout=30000
 spring.datasource.hikari.max-lifetime=1800000
 
 # ===============================
+# Flyway
+# ===============================
+spring.flyway.enabled=true
+spring.flyway.locations=classpath:db/migration
+
+# ===============================
 # JPA / Hibernate
 # ===============================
 spring.jpa.hibernate.ddl-auto=none

--- a/src/main/resources/db/migration/V1__create_providers_table.sql
+++ b/src/main/resources/db/migration/V1__create_providers_table.sql
@@ -1,0 +1,13 @@
+CREATE EXTENSION IF NOT EXISTS postgis;
+
+CREATE TABLE providers (
+    id UUID PRIMARY KEY,
+    business_name VARCHAR(255) NOT NULL,
+    services VARCHAR(255) NOT NULL,
+    rating NUMERIC,
+    street VARCHAR(255),
+    city VARCHAR(255),
+    state VARCHAR(255),
+    zip VARCHAR(20),
+    location geometry(Point,4326)
+);


### PR DESCRIPTION
## Summary
- include Flyway dependencies for database migrations
- configure Flyway for Postgres with environment-specific toggles
- add initial migration creating providers table

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b27aa73414832c9ebf414feaa77dfa